### PR TITLE
amigo - ChatBar component  does not extend to same width as ChatWindow

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,13 @@ module.exports = {
 				"2xl": "1400px",
 			},
 		},
-		extend: {},
+		extend: {
+			// Adding custom styles for consistency across ChatBar and ChatWindow
+            width: {
+                'chat-bar': 'calc(100% - 2rem)',
+            },
+		},
 	},
 	plugins: [require("tailwindcss-animate"), require("@tailwindcss/forms")],
 };
+


### PR DESCRIPTION
Working on [amigo - ChatBar component  does not extend to same width as ChatWindow](https://github.com/pureit-dev/chatapp/issues/3)
‎
To ensure the ChatBar component extends to the same width as the ChatWindow component, the Tailwind CSS configuration will be adjusted to include custom styles that ensure consistency in width across these components.