### PR TITLE
amigo - ensure that the chatbar extends the full width of the chat window

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,22 +4,28 @@ module.exports = {
 	content: [
 		"./pages/**/*.{ts,tsx}",
 		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
+		"./app/**/**/*.{ts,tsx}",
 		"./src/**/*.{ts,tsx}",
 	],
 	theme: {
 		container: {
 			center: true,
-			padding: "2rem",
+			padding: {
+				DEFAULT: '2rem', // Consistent padding for the sake of responsiveness
+				sm: '2rem',
+				md: '2rem',
+				lg: '2rem',
+				xl: '2rem',
+				'2xl': '2rem',
+			},
 			screens: {
 				"2xl": "1400px",
 			},
 		},
 		extend: {
-			// Adding custom styles for consistency across ChatBar and ChatWindow
-            width: {
-                'chat-bar': 'calc(100% - 2rem)',
-            },
+			maxWidth: {
+				'chatbar': 'none', // Allowing the chatbar component to extend fully
+			}
 		},
 	},
 	plugins: [require("tailwindcss-animate"), require("@tailwindcss/forms")],


### PR DESCRIPTION
Working on [amigo - ensure that the chatbar extends the full width of the chat window](https://github.com/pureit-dev/chatapp/issues/5)
‎
Updating the Tailwind configuration to ensure the chatbar extends the full width of the chat window. This might involve modifying the container settings or direct styling of the chatbar component itself.