### PR TITLE
amigo - ensure that the chatbar extends the full width of the chat window

### DIFF
--- a/src/components/sections/chatBar.tsx
+++ b/src/components/sections/chatBar.tsx
@@ -5,7 +5,7 @@ interface ChatBarProps {
 	input: string;
 	isLoading: boolean;
 	handleInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
-	handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
+	handleSubmit: (e: FormDateEvent<HTMLFormElement>) => void;
 }
 
 const ChatBar: React.FC<ChatBarProps> = ({
@@ -17,9 +17,9 @@ const ChatBar: React.FC<ChatBarProps> = ({
 	return (
 		<div className="flex justify-center my-5 ">
 			<form onSubmit={handleSubmit}>
-				<div className="flex flex-row w-screen max-w-screen-lg px-5 space-x-3">
+				<div className="flex flex-row w-full px-5 space-x-3"> <!-- Updated this line -->
 					<input
-						className="shadow-md focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-slate-300 border-2 rounded-md"
+						className="shadow-md focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-slate-300 border-2 rounded-md flex-grow"
 						type="text"
 						placeholder="Type a message..."
 						value={input}
@@ -45,3 +45,4 @@ const ChatBar: React.FC<ChatBarProps> = ({
 };
 
 export default ChatBar;
+


### PR DESCRIPTION
Working on [amigo - ensure that the chatbar extends the full width of the chat window](https://github.com/pureit-dev/chatapp/issues/5)
‎
To ensure the ChatBar extends the full width of the chat window, the flex row container inside the ChatBar component will be updated to extend its width to match its parent container. This change does not require modifications to configuration files or addition of new files.