### PR TITLE
Amigo simplify programming languages

### DIFF
--- a/src/components/ui/codeblock.tsx
+++ b/src/components/ui/codeblock.tsx
@@ -10,79 +10,62 @@ import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { Button } from "@/components/ui/button";
 
 interface Props {
-	language: string;
-	value: string;
+  language: string;
+  value: string;
 }
 
 interface languageMap {
-	[key: string]: string | undefined;
+  [key: string]: string | undefined;
 }
 
 export const programmingLanguages: languageMap = {
-	javascript: ".js",
-	python: ".py",
-	java: ".java",
-	c: ".c",
-	cpp: ".cpp",
-	"c++": ".cpp",
-	"c#": ".cs",
-	ruby: ".rb",
-	php: ".php",
-	swift: ".swift",
-	"objective-c": ".m",
-	kotlin: ".kt",
-	typescript: ".ts",
-	go: ".go",
-	perl: ".pl",
-	rust: ".rs",
-	scala: ".scala",
-	haskell: ".hs",
-	lua: ".lua",
-	shell: ".sh",
-	sql: ".sql",
-	html: ".html",
-	css: ".css",
-	// add more file extensions here, make sure the key is same as language prop in CodeBlock.tsx component
+  java: ".java",
+  ruby: ".rb",
+  perl: ".pl",
+  rust: ".rs",
+  go: ".go",
+  // Reduced list of supported languages as per request
 };
 
 export const generateRandomString = (length: number, lowercase = false) => {
-	const chars = "ABCDEFGHJKLMNPQRSTUVWXY3456789"; // excluding similar looking characters like Z, 2, I, 1, O, 0
-	let result = "";
-	for (let i = 0; i < length; i++) {
-		result += chars.charAt(Math.floor(Math.random() * chars.length));
-	}
-	return lowercase ? result.toLowerCase() : result;
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXY3456789"; // excluding similar looking characters like Z, 2, I, 1, O, 0
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return lowercase ? result.toLowerCase() : result;
 };
 
 const CodeBlock: FC<Props> = memo(({ language, value }) => {
-	return (
-		<div className="relative w-full font-sans codeblock bg-zinc-950">
-			<div className="flex items-center justify-between w-full px-6 py-2 pr-4 bg-zinc-800 text-zinc-100">
-				<span className="text-xs lowercase">{language}</span>
-			</div>
-			<SyntaxHighlighter
-				language={language}
-				style={coldarkDark}
-				PreTag="div"
-				showLineNumbers
-				customStyle={{
-					margin: 0,
-					width: "100%",
-					background: "transparent",
-					padding: "1.5rem 1rem",
-				}}
-				codeTagProps={{
-					style: {
-						fontSize: "0.9rem",
-						fontFamily: "var(--font-mono)",
-					},
-				}}
-			>
-				{value}
-			</SyntaxHighlighter>
-		</div>
-	);
+  return (
+    <div className="relative w-full font-sans codeblock bg-zinc-950">
+      <div className="flex items-center justify-between w-full px-6 py-2 pr-4 bg-zinc-800 text-zinc-100">
+        <span className="text-xs lowercase">{language}</span>
+      </div>
+      <SyntaxHighlighter
+        language={language}
+        style={coldarkDark}
+        PreTag="div"
+        showLineNumbers
+        customStyle={{
+          margin: 0,
+          width: "100%",
+          background: "transparent",
+          padding: "1.5rem 1rem",
+        }}
+        codeTagProps={{
+          style: {
+            fontSize: "0.9rem",
+            fontFamily: "var(--font-mono)",
+          },
+        }}
+      >
+        {value}
+      </SyntaxHighlighter>
+    </div>
+  );
 });
 CodeBlock.displayName = "CodeBlock";
 
 export { CodeBlock };
+


### PR DESCRIPTION
Resolves #14 ([Amigo simplify programming languages](https://github.com/pureit-dev/chatapp/issues/14))
‎
Reduce the supported programming languages in the `codeblock.tsx` component to only Java, Ruby, Perl, Rust, and Go by adjusting the `programmingLanguages` map.