### PR TITLE
Amigo change the tailwind styles to make the app more 'noir' themed

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="en">
-			<body className="box-border flex flex-col h-screen max-w-screen-lg justify-between my-0 mx-auto">
+			<body className="box-border flex flex-col h-screen max-w-screen-lg justify-between my-0 mx-auto bg-noir-bg text-noir-text">
 				<ThemeProvider
 					attribute="class"
 					defaultTheme="system"
@@ -32,3 +32,4 @@ export default function RootLayout({
 		</html>
 	);
 }
+

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -5,7 +5,7 @@ import { metadata } from "@/app/layout";
 const Header = () => {
 	const { title } = metadata as { title: string };
 	return (
-		<header className="flex justify-between items-center p-5">
+		<header className="flex justify-between items-center p-5 bg-noir-accent text-noir-text">
 			<h1 className="text-2xl font-bold text-center">
 				{title}
 			</h1>
@@ -18,3 +18,4 @@ const Header = () => {
 };
 
 export default Header;
+

--- a/src/components/sections/chatBar.tsx
+++ b/src/components/sections/chatBar.tsx
@@ -19,7 +19,7 @@ const ChatBar: React.FC<ChatBarProps> = ({
 			<form onSubmit={handleSubmit} className="w-full">
 				<div className="flex flex-row w-full px-5 space-x-3">
 					<input
-						className="shadow-md focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-slate-300 border-2 rounded-md flex-grow"
+						className="shadow-md focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-slate-300 border-2 rounded-noir flex-grow bg-noir-bg text-noir-text border-noir-border"
 						type="text"
 						placeholder="Type a message..."
 						value={input}
@@ -28,7 +28,7 @@ const ChatBar: React.FC<ChatBarProps> = ({
 					/>
 					<button
 						type="submit"
-						className="rounded bg-indigo-600 px-2 py-1 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+						className="rounded-noir bg-noir-accent px-2 py-1 text-xs font-semibold text-noir-text shadow-sm hover:bg-opacity-80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-noir-accent"
 					>
 						{isLoading ? (
 							<svg
@@ -48,3 +48,4 @@ const ChatBar: React.FC<ChatBarProps> = ({
 };
 
 export default ChatBar;
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,13 +5,13 @@ module.exports = {
 		"./pages/**/*.{ts,tsx}",
 		"./components/**/*.{ts,tsx}",
 		"./app/**/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
+		"./src/**/*.{ts,tsx}"
 	],
 	theme: {
 		container: {
 			center: true,
 			padding: {
-				DEFAULT: '2rem', // Consistent padding for the sake of responsiveness
+				DEFAULT: '2rem',
 				sm: '2rem',
 				md: '2rem',
 				lg: '2rem',
@@ -23,8 +23,17 @@ module.exports = {
 			},
 		},
 		extend: {
+			colors: {
+				'noir-bg': '#121212', // Adding noir theme background color
+				'noir-text': '#E3E3E3', // Adding noir theme text color
+				'noir-accent': '#B1A7A6', // Adding an accent color for noir theme
+				'noir-border': '#333333', // Border color for inputs and buttons in noir theme
+			},
+			borderRadius: {
+				'noir': '0.25rem', // Applying subtle borderRadius for the noir theme
+			},
 			maxWidth: {
-				'chatbar': 'none', // Allowing the chatbar component to extend fully
+				'chatbar': 'none',
 			}
 		},
 	},


### PR DESCRIPTION
Resolves #16 ([Amigo change the tailwind styles to make the app more 'noir' themed](https://github.com/pureit-dev/chatapp/issues/16))
‎
Modifying the TailwindCSS configuration and component styles to adopt a 'noir' theme, which will primarily involve changes to colors, border styles, and shadows for a darker, more atmospheric look suitable for a noir aesthetic.