### PR TITLE
Amigo add a placeholder logo to the header bar

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -6,9 +6,12 @@ const Header = () => {
 	const { title } = metadata as { title: string };
 	return (
 		<header className="flex justify-between items-center p-5">
-			<h1 className="text-2xl font-bold text-center">
-				{title}
-			</h1>
+            <div className="flex items-center gap-4">
+                <img src="https://png.pngtree.com/png-clipart/20190604/original/pngtree-creative-company-logo-png-image_1197025.jpg" alt="Company Logo" className="w-12 h-12" />
+			    <h1 className="text-2xl font-bold text-center">
+				    {title}
+			    </h1>
+            </div>
 			<div className="flex gap-2">
 				<ModeToggle />
 				
@@ -18,3 +21,4 @@ const Header = () => {
 };
 
 export default Header;
+


### PR DESCRIPTION
Resolves #18 ([Amigo add a placeholder logo to the header bar](https://github.com/pureit-dev/chatapp/issues/18))
‎
A placeholder logo will be added to the header bar, positioned before the title.